### PR TITLE
Better abstraction by hiding struct stack internals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,16 @@
+#ignore all
+*
+#unignore all with extensions
+!*.*
+#unignore all dirs
+!*/
+#combination above will ignore all files without extensions
+
+#ignore scripts
+*.sh
+
+#ignore object files(generates)
+*.o
+
+#line below was initially in this repo
 .*.swp

--- a/pointers/421/stack_management.c
+++ b/pointers/421/stack_management.c
@@ -1,8 +1,17 @@
 #include "stack_management.h"
 
-struct stack *stackdbl_init()
+#define STACK_SIZE 6
+#define MUL_SIZE 2
+
+struct stack {
+    double *data;      // array numbers
+    int size;          // size array 
+    int top;           // pointer to top of stack
+};
+
+Stack stackdbl_init()
 {
-    struct stack *st = NULL;
+    Stack st = NULL;
     st = malloc(sizeof(struct stack));
     st->size = STACK_SIZE;
     st->top = 0;
@@ -10,19 +19,19 @@ struct stack *stackdbl_init()
     return st;
 }
 
-void stackdbl_destroy(struct stack *st)
+void stackdbl_destroy(Stack st)
 {
     free(st->data);
     free(st);
     st = NULL;
 }
 
-int stackdbl_empty(struct stack *st)
+int stackdbl_empty(Stack st)
 {
     return st->top == 0;
 }
 
-struct stack *stackdbl_resize(struct stack *st)
+Stack stackdbl_resize(Stack st)
 {
     int i;
     double *tmp = malloc(st->size * sizeof(double));
@@ -39,7 +48,7 @@ struct stack *stackdbl_resize(struct stack *st)
     return st;
 }
 
-int stackdbl_push(struct stack *st, double n)
+int stackdbl_push(Stack st, double n)
 {
     if(st->size - 1 == st->top) {
         st = stackdbl_resize(st);
@@ -48,7 +57,7 @@ int stackdbl_push(struct stack *st, double n)
     return 0;
 }
 
-double stackdbl_pop(struct stack *st)
+double stackdbl_pop(Stack st)
 {
     if(!stackdbl_empty(st)) {
         return st->data[--st->top];

--- a/pointers/421/stack_management.h
+++ b/pointers/421/stack_management.h
@@ -2,20 +2,14 @@
 #include <stdlib.h>
 #ifndef STACK_MANAGEMENT
 #define STACK_MANAGEMENT
-#define STACK_SIZE 6
-#define MUL_SIZE 2
 
-struct stack {
-    double *data;      // array numbers
-    int size;          // size array 
-    int top;           // pointer to top of stack
-};
+typedef struct stack *Stack;
 
-struct stack *stackdbl_init();
-void stackdbl_destroy(struct stack *st);
-int stackdbl_empty(struct stack *st);
-struct stack *stackdbl_resize(struct stack *st);
-int stackdbl_push(struct stack *st, double n);
-double stackdbl_pop(struct stack *st);
+Stack stackdbl_init();
+void stackdbl_destroy(Stack);
+int stackdbl_empty(Stack);
+Stack stackdbl_resize(Stack);
+int stackdbl_push(Stack, double);
+double stackdbl_pop(Stack);
 
 #endif

--- a/pointers/421/task421.c
+++ b/pointers/421/task421.c
@@ -6,7 +6,7 @@ int main()
 {
     int i;
     double n;
-    struct stack *stack = stackdbl_init();
+    Stack stack = stackdbl_init();
     for (i = 1; i < 10; i++) {
         stackdbl_push(stack, sin(i));
     }


### PR DESCRIPTION
Modified interface "stack_management.h": replaced stack structure internals to a pointer to
struct stack (i.e descriptor) so that a user cannot directly access struct stack's fields.
Also moved realization specific defines to stack_management.c from the interface.
The realization of interface "stack_management.c" and client program "task421.c" have been changed accordingly.
Edited .gitignore so that shell scripts and object files after compilation won't be tracked by Git.
Inspired by R. Sedgewick Algorithms in C chapter 4.